### PR TITLE
Add key bindings for window cycling in Hyprland

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -377,6 +377,8 @@ bind = $mod, V, togglefloating,
 bind = $mod, J, togglesplit,
 bind = $mod, P, pseudo,
 bind = $mod, TAB, exec, $HOME/.local/share/archriot/install/archriot --switch-window
+bind = ALT, TAB, exec, hyprctl dispatch cyclenext visible
+bind = ALT SHIFT, TAB, exec, hyprctl dispatch cyclenext prev visible
 
 # Fix off-screen windows (manual trigger)
 bind = $mod SHIFT, TAB, exec, $HOME/.local/share/archriot/install/archriot --fix-offscreen-windows


### PR DESCRIPTION
Adds the default expected 'alt-tab' behavior to cycle between all windows on all workspaces