### PR TITLE
Adjust border width and radius in fuzzel.ini

### DIFF
--- a/config/fuzzel/fuzzel.ini
+++ b/config/fuzzel/fuzzel.ini
@@ -73,8 +73,8 @@ border=9d7bd8ff
 
 [border]
 # Border settings - match fuzzel styling
-width=2
-radius=10
+width=1
+radius=8
 
 [dmenu]
 # dmenu mode settings (for scripts)


### PR DESCRIPTION
Adjusted border width and radius settings for fuzzel to match the current hyprland theme for consistency and harmony