### PR TITLE
Configure gnome apps to prefer dark themes

### DIFF
--- a/config/hypr/hyprland.conf
+++ b/config/hypr/hyprland.conf
@@ -22,6 +22,9 @@ env = HYPRCURSOR_THEME,Bibata-Modern-Ice
 env = XCURSOR_SIZE,24
 env = HYPRCURSOR_SIZE,24
 
+# Prefer dark themes on all gnome apps
+exec-once = gsettings set org.gnome.desktop.interface color-scheme 'prefer-dark'
+
 # Autostart applications
 exec-once = $HOME/.local/share/archriot/install/archriot --waybar-launch
 exec-once = mako


### PR DESCRIPTION
Set GNOME apps to prefer dark themes. This will make gnome system monitor, calculator etc and any newly installed GNOME user-app to prefer a dark theme and fit the overall theme context.