### PR TITLE
Waybar clean-up and persist user modules.

### DIFF
--- a/config/waybar/Modules
+++ b/config/waybar/Modules
@@ -1,7 +1,8 @@
 /* ArchRiot Waybar Modules */
-/* Core system modules for waybar configuration */
+/* Core system modules for Waybar configuration */
 
-/* NOTE: hyprland-workspaces, Custom Modules, Custom Vertical & Groups on a separate files */
+/* NOTE: Workspaces, Custom Modules, Vertical & Groups on separate files */
+/* NOTE: Changes will only be kept in user files: UserModules, UserWorkspaces */
 
 {
 

--- a/config/waybar/ModulesCustom
+++ b/config/waybar/ModulesCustom
@@ -1,16 +1,48 @@
 /* ArchRiot Waybar Custom Modules */
 /* Custom modules for enhanced waybar functionality */
 /* Separated from main modules for better organization */
-/* NOTE: This is only for Custom Modules */
 /* Custom Modules like weather browser, tty, file manager at the beginning */
 
+/* NOTE: This is only for ArchRiot Custom Modules */
+/* NOTE: Changes will only be kept in user files: UserModules, UserWorkspaces */
+
 {
+	// "custom/arch": {
+    //     "format": "󰣇",
+    //     "on-click": "nwg-drawer -c 4 -is 48 -spacing 15 -fm \"Noto Sans\" || fuzzel",
+    //     "on-click-right": "pkill fuzzel || fuzzel",
+    //     "tooltip": true,
+    //     "tooltip-format": "Left Click: Application Grid\nRight Click: Fuzzel Launcher"
+    // },
+	// ----- ArchRiot theme specific module override (this was in `/config`)
+	"custom/arch": {
+		"format": "󰣇",
+		"on-click": "nwg-drawer -c 4 -is 48 -spacing 15 -fm \"Noto Sans\" || fuzzel",
+		"on-click-right": "pkill fuzzel || fuzzel",
+		"tooltip": true,
+		"tooltip-format": "Left-click: App Drawer | Right-click: Fuzzel"
+	},
+
     "custom/archriot-update": {
     	"exec": "$HOME/.config/waybar/scripts/archriot-update.sh",
     	"return-type": "json",
     	"interval": 300,
     	"on-click": "$HOME/.config/waybar/scripts/archriot-update.sh --click",
     	"tooltip": true,
+    },
+	// This was in `/UserModules`:
+	"custom/media": {
+        "on-click-middle": "playerctl previous",
+        "on-click": "playerctl play-pause",
+        "format": "{icon} {}",
+        "max-length": 40,
+        "on-click-right": "playerctl next",
+        "format-icons": {
+            "Playing": "󰎈",
+            "Paused": "󰏤"
+        },
+        "return-type": "json",
+        "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{title}}\", \"tooltip\": \"{{playerName}} : {{artist}} - {{album}} - {{title}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F"
     },
 
     "custom/lock": {
@@ -180,6 +212,15 @@
     	"format": "",
     	"tooltip": false
     },
+	// This was in `/UserModules`:
+	// "custom/mullvad": {
+    //     "exec": "$HOME/.config/waybar/scripts/mullvad-status.sh",
+    //     "return-type": "json",
+    //     "interval": 5,
+    //     "on-click": "$HOME/.config/waybar/scripts/mullvad-click.sh left",
+    //     "on-click-right": "$HOME/.config/waybar/scripts/mullvad-click.sh right",
+    //     "tooltip": true
+    // },
     "custom/mullvad": {
     	"format": "{}",
     	"return-type": "json",

--- a/config/waybar/UserModules
+++ b/config/waybar/UserModules
@@ -1,30 +1,14 @@
-{
-    "custom/mullvad": {
-        "exec": "$HOME/.config/waybar/scripts/mullvad-status.sh",
-        "return-type": "json",
-        "interval": 5,
-        "on-click": "$HOME/.config/waybar/scripts/mullvad-click.sh left",
-        "on-click-right": "$HOME/.config/waybar/scripts/mullvad-click.sh right",
-        "tooltip": true
-    },
-    "custom/media": {
-        "on-click-middle": "playerctl previous",
-        "on-click": "playerctl play-pause",
-        "format": "{icon} {}",
-        "max-length": 40,
-        "on-click-right": "playerctl next",
-        "format-icons": {
-            "Playing": "󰎈",
-            "Paused": "󰏤"
-        },
-        "return-type": "json",
-        "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{title}}\", \"tooltip\": \"{{playerName}} : {{artist}} - {{album}} - {{title}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' -F"
-    },
-    "custom/arch": {
-        "format": "󰣇",
-        "on-click": "nwg-drawer -c 4 -is 48 -spacing 15 -fm \"Noto Sans\" || fuzzel",
-        "on-click-right": "pkill fuzzel || fuzzel",
-        "tooltip": true,
-        "tooltip-format": "Left Click: Application Grid\nRight Click: Fuzzel Launcher"
-    }
-}
+/* ArchRiot Waybar User Modules */
+/* Add your own custom modules here (this file will be kept by the installer)*/
+
+// E.g.: User module for cava stereo bars
+// {
+//     "custom/cava_left": {
+//         "format": "{}",
+//         "exec": "~/bin/waybar_cava.sh --left"
+//     },
+//     "custom/cava_right": {
+//         "format": "{}",
+//         "exec": "~/bin/waybar_cava.sh --right"
+//     } 
+// }

--- a/config/waybar/config
+++ b/config/waybar/config
@@ -1,9 +1,15 @@
+/* ArchRiot Waybar Configuration */
+/* Main Waybar configuration file */
+
+/* NOTE: This files will be replaced and backed-up as .old after an update */
+/* NOTE: Changes will only be kept in user files: UserModules, UserWorkspaces */
+
 [
     {
         "include": [
             "$HOME/.config/waybar/Modules",
-            "$HOME/.config/waybar/ModulesWorkspaces",
             "$HOME/.config/waybar/ModulesCustom",
+            "$HOME/.config/waybar/ModulesWorkspaces",
             "$HOME/.config/waybar/ModulesGroups",
             "$HOME/.config/waybar/UserModules",
             "$HOME/.config/waybar/UserWorkspaces"
@@ -62,20 +68,12 @@
             "custom/separator#blank",
             "group/status",
             "custom/lock"              // Lockscreen
-        ],
-    
-        // ----- ArchRiot theme specific module override
-        "custom/arch": {
-            "format": "󰣇",
-            "on-click": "nwg-drawer -c 4 -is 48 -spacing 15 -fm \"Noto Sans\" || fuzzel",
-            "on-click-right": "pkill fuzzel || fuzzel",
-            "tooltip": true,
-            "tooltip-format": "Left-click: App Drawer | Right-click: Fuzzel"
-        }
+        ]
     }
 
     // ----- For another waybar with different content on the same or another screen:
     // e.g.: A bottom bar with clock on DP-1 only.
+    // *note the comma*
     //,{
         // Start a new waybar here.
         // "include": ["$HOME/.config/waybar/Modules"],  // Required for 'clock' module

--- a/install/packages.yaml
+++ b/install/packages.yaml
@@ -102,7 +102,7 @@ desktop:
               preserve_if_exists:
                   [monitors.conf, keybindings.conf, windowrules.conf]
             - pattern: waybar/*
-              preserve_if_exists: [UserWorkspaces]
+              preserve_if_exists: [UserWorkspaces, UserModules]
             - pattern: fuzzel/*
             - pattern: mako/*
             - pattern: Thunar/*


### PR DESCRIPTION
Reorganized Waybar config files so users can have `UserModules` and `UserWorkspaces` preserved (shipped with empty templates) and all ArchRiot custom modules that were scattered around are now in ModulesCustom. Added documentation header to all files and UserModules to keep in packages.yaml.

This should mimic the behavior added to hyprland user config files (monitors, keybindings, windowrules) giving the installer/updater freedom to replace main config files and fix broken installswhile keeping another piece of user customization in the process.